### PR TITLE
Fixing migrations

### DIFF
--- a/paper/migrations/0001_squashed_0006_auto_20160827_0901.py
+++ b/paper/migrations/0001_squashed_0006_auto_20160827_0901.py
@@ -83,18 +83,20 @@ class Migration(migrations.Migration):
                 ('paper_file', models.FileField(upload_to='uploads')),
             ],
         ),
-        migrations.CreateModel(
-            name='Subject',
-            fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=40)),
-            ],
-        ),
-        migrations.AddField(
-            model_name='paper',
-            name='subject',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='paper.Subject'),
-        ),
+       
+        #migrations.CreateModel(
+        #    name='Subject',
+        #    fields=[
+        #        ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+        #        ('name', models.CharField(max_length=40)),
+        #    ],
+        #),
+        #migrations.AddField(
+        #    model_name='paper',
+        #    name='subject',
+        #    field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='paper.Subject'),
+        #),
+       
         migrations.AlterField(
             model_name='paper',
             name='paper_file',
@@ -118,15 +120,17 @@ class Migration(migrations.Migration):
             name='tags',
             field=models.ManyToManyField(to=b'paper.Tag'),
         ),
-        migrations.RunPython(
-            code=subject_to_tag,
-            reverse_code=reverse_subject_to_tag,
-        ),
-        migrations.RemoveField(
-            model_name='paper',
-            name='subject',
-        ),
-        migrations.DeleteModel(
-            name='Subject',
-        ),
+       
+        #migrations.RunPython(
+        #    code=subject_to_tag,
+        #    reverse_code=reverse_subject_to_tag,
+        #),
+       
+        #migrations.RemoveField(
+        #    model_name='paper',
+        #    name='subject',
+        #),
+        #migrations.DeleteModel(
+        #    name='Subject',
+        #),
     ]

--- a/paper/migrations/0001_squashed_0006_auto_20160827_0901.py
+++ b/paper/migrations/0001_squashed_0006_auto_20160827_0901.py
@@ -84,19 +84,6 @@ class Migration(migrations.Migration):
             ],
         ),
        
-        #migrations.CreateModel(
-        #    name='Subject',
-        #    fields=[
-        #        ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-        #        ('name', models.CharField(max_length=40)),
-        #    ],
-        #),
-        #migrations.AddField(
-        #    model_name='paper',
-        #    name='subject',
-        #    field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='paper.Subject'),
-        #),
-       
         migrations.AlterField(
             model_name='paper',
             name='paper_file',
@@ -120,17 +107,5 @@ class Migration(migrations.Migration):
             name='tags',
             field=models.ManyToManyField(to=b'paper.Tag'),
         ),
-       
-        #migrations.RunPython(
-        #    code=subject_to_tag,
-        #    reverse_code=reverse_subject_to_tag,
-        #),
-       
-        #migrations.RemoveField(
-        #    model_name='paper',
-        #    name='subject',
-        #),
-        #migrations.DeleteModel(
-        #    name='Subject',
-        #),
+
     ]


### PR DESCRIPTION
Removed the subject model in the squashed migration file.
This was causing issues in new clones with postgres db.
